### PR TITLE
Fixed fury warriors and enhance shamans not loading when using dual-wield and character's robes

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 Project support closed. Repository (http://github.com/Shadez/wowarmory/) will stay as archive.
 
-Armory core will be rewrited and updated in near future, stay tuned.
+Armory core will be rewritten and updated in near future, stay tuned.
 
 WARNING: You must not remove and/or change any Blizzard's copyrights in any files and/or at the bottom of Armory pages!
 

--- a/character-model.php
+++ b/character-model.php
@@ -135,26 +135,6 @@ $xml->XMLWriter()->startElement('model');
 foreach($model_data as $model_key => $model_value) {
     $xml->XMLWriter()->writeAttribute($model_key, $model_value);
 }
-$xml->XMLWriter()->startElement('components');
-$components = array(100, 200, 801, 401, 601, $character_model_data['hair_style'], 901, 302, 1600, 1201, 702, 1001, 1401, 1501, 0, 101, 301, 1101, 502, 1502);
-if($characters->GetGender() == 1) {
-    $components[count($components)+1] = 1302; // Legs type
-}
-else {
-    $components[count($components)+1] = 1301; // Legs type
-}
-if($characters->GetRace() == RACE_BLOODELF) {
-    $components[count($components)+1] = 1702; // Eyes
-}
-if($characters->GetClass() == CLASS_DK) {
-    $components[count($components)+1] = 1703; // Eyes
-}
-foreach($components as $component) {
-    $xml->XMLWriter()->startElement('component');
-    $xml->XMLWriter()->writeAttribute('n', $component);
-    $xml->XMLWriter()->endElement();
-}
-$xml->XMLWriter()->endElement(); //components
 $subtexture_data = array();
 /** MAIN TEXTURES **/
 /*
@@ -647,6 +627,28 @@ if($tmpid = $characters->GetCharacterEquip('offhand')) {
     	unset($tmpid);
     }
 }
+$xml->XMLWriter()->startElement('components');
+$components = array(100, 200, 801, 401, 601, $character_model_data['hair_style'], 901, 302, 1600, 1201, 702, 1001, 1401, 1501, 0, 101, 301, 1101, 1502);
+if(isset($subtexture_data['leg_ll']))
+{
+	$components[count($components)+1] = 1301; // Legs type (with robe)
+	$components[count($components)+1] = 502; // Removes boots texture
+}else {
+	$components[count($components)+1] = 1302; // Legs type (no robe)
+	$components[count($components)+1] = 500; // Adds boots texture
+}
+if($characters->GetRace() == RACE_BLOODELF) {
+    $components[count($components)+1] = 1702; // Eyes
+}
+if($characters->GetClass() == CLASS_DK) {
+    $components[count($components)+1] = 1703; // Eyes
+}
+foreach($components as $component) {
+    $xml->XMLWriter()->startElement('component');
+    $xml->XMLWriter()->writeAttribute('n', $component);
+    $xml->XMLWriter()->endElement();
+}
+$xml->XMLWriter()->endElement(); //components
 $xml->XMLWriter()->startElement('textures');
 $xml->XMLWriter()->startElement('texture');
 $xml->XMLWriter()->writeAttribute('file', sprintf('character/%s/%s/%s%sskin00_%s.png', $character_model_data['race'], $character_model_data['gender'], $character_model_data['race'], $character_model_data['gender'], $character_model_data['skin_style']));

--- a/character-model.php
+++ b/character-model.php
@@ -599,7 +599,7 @@ if($tmpid = $characters->GetCharacterEquip('mainhand')) {
          **/
         $model_data_attachment['main_hand_texture'] = array(
             'linkPoint' => 1,
-            'type' => 'none',
+            'type' => 'melee',
             'modelFile' => 'item/objectcomponents/weapon/'.$items->GetItemModelData($displayId, 'modelName_1', $tmpid).'.m2',
             'skinFile' => 'item/objectcomponents/weapon/'.$items->GetItemModelData($displayId, 'modelName_1', $tmpid).'00.skin',   // What does 00 means?
             'texture' => 'item/objectcomponents/weapon/'.$items->GetItemModelData($displayId, 'modelTexture_1', $tmpid).'.png',
@@ -613,41 +613,39 @@ if($tmpid = $characters->GetCharacterEquip('mainhand')) {
 /**
  * Off hand (texture)
  **/
-if($characters->GetClass() == CLASS_PALADIN || $characters->GetClass() == CLASS_WARRIOR || $characters->GetClass() == CLASS_SHAMAN) {
-    if($tmpid = $characters->GetCharacterEquip('offhand')) {
-        $displayId = $items->GetItemInfo($tmpid, 'displayid');
-        $model_data_attachment['off_hand_texture'] = array(
-            'linkPoint' => 0,
-            'type' => 'melee',
-            'modelFile' => 'item/objectcomponents/shield/'.$items->GetItemModelData($displayId, 'modelName_1', $tmpid).'.m2',
-            'skinFile' => 'item/objectcomponents/shield/'.$items->GetItemModelData($displayId, 'modelName_1', $tmpid).'00.skin',   // What does 00 means?
-            'texture' => 'item/objectcomponents/shield/'.$items->GetItemModelData($displayId, 'modelTexture_1', $tmpid).'.png',
-        );
-        if($model_data_attachment['off_hand_texture']['texture'] == 'item/objectcomponents/shield/.png') {
-            unset($model_data_attachment['off_hand_texture']);
-            $model_data['use_shield'] = false;
-        }
-        else {
-            $model_data['use_shield'] = true;
-        }
+if($tmpid = $characters->GetCharacterEquip('offhand')) {
+    $InventoryType = $items->GetItemInfo($tmpid, 'InventoryType');
+    $displayId = $items->GetItemInfo($tmpid, 'displayid');
+    if($InventoryType == 14) {
+    	$model_data_attachment['off_hand_texture'] = array(
+	   		'linkPoint' => 0,
+	    	'type' => 'melee',
+	    	'modelFile' => 'item/objectcomponents/shield/'.$items->GetItemModelData($displayId, 'modelName_1', $tmpid).'.m2',
+	    	'skinFile' => 'item/objectcomponents/shield/'.$items->GetItemModelData($displayId, 'modelName_1', $tmpid).'00.skin',   // What does 00 means?
+	    	'texture' => 'item/objectcomponents/shield/'.$items->GetItemModelData($displayId, 'modelTexture_1', $tmpid).'.png',
+    	);
+		if($model_data_attachment['off_hand_texture']['texture'] == 'item/objectcomponents/shield/.png') {
+		    unset($model_data_attachment['off_hand_texture']);
+		   	$model_data['use_shield'] = false;
+		}
+	    else {
+	    	$model_data['use_shield'] = true;
+	    }
+	    unset($tmpid);
     }
-    unset($tmpid);
-}
-else {
-    if($tmpid = $characters->GetCharacterEquip('offhand')) {
-        $displayId = $items->GetItemInfo($tmpid, 'displayid');
-        $model_data_attachment['off_hand_texture'] = array(
-            'linkPoint' => 1,
-            'type' => 'ranged',
-            'modelFile' => 'item/objectcomponents/weapon/'.$items->GetItemModelData($displayId, 'modelName_1', $tmpid).'.m2',
-            'skinFile'  => 'item/objectcomponents/weapon/'.$items->GetItemModelData($displayId, 'modelName_1', $tmpid).'00.skin',   // What does 00 means?
-            'texture'   => 'item/objectcomponents/weapon/'.$items->GetItemModelData($displayId, 'modelTexture_1', $tmpid).'.png',
-        );
-        if($model_data_attachment['off_hand_texture']['texture'] == 'item/objectcomponents/weapon/.png') {
-            unset($model_data_attachment['off_hand_texture']);
-        }
+    else {
+    	$model_data_attachment['off_hand_texture'] = array(
+    			'linkPoint' => 2,
+    			'type' => 'melee',
+    			'modelFile' => 'item/objectcomponents/weapon/'.$items->GetItemModelData($displayId, 'modelName_1', $tmpid).'.m2',
+    			'skinFile'  => 'item/objectcomponents/weapon/'.$items->GetItemModelData($displayId, 'modelName_1', $tmpid).'00.skin',   // What does 00 means?
+    			'texture'   => 'item/objectcomponents/weapon/'.$items->GetItemModelData($displayId, 'modelTexture_1', $tmpid).'.png',
+    	);
+    	if($model_data_attachment['off_hand_texture']['texture'] == 'item/objectcomponents/weapon/.png') {
+    		unset($model_data_attachment['off_hand_texture']);
+    	}
+    	unset($tmpid);
     }
-    unset($tmpid);
 }
 $xml->XMLWriter()->startElement('textures');
 $xml->XMLWriter()->startElement('texture');


### PR DESCRIPTION
Versioning system seems to be fucked up a bit, so i didn't add the tag.

Problem with the dual-wield was caused by:
if($characters->GetClass() == CLASS_PALADIN || $characters->GetClass() == CLASS_WARRIOR || $characters->GetClass() == CLASS_SHAMAN)

Which expected every paladin, warrior and shaman to be using either a two hander, or a one hander with shield. It did not include the fact that fury warriors and enhance shamans are dual-wield.

And the problem with the robes was caused by
if($characters->GetGender() == 1)

Which guessed that all female characters wore robes and no males (what?). This also moves the components section of code to the bottom of the file so we can check if texture var's are being set.

---

Damn I'm so bad at using github's pulling system. Still haven't figured out how to make separate pull requests.
